### PR TITLE
Dispatch on subtype of Constant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
 DiskArrays = "0.2.4"
-Interpolations = "0.12"
+Interpolations = "0.12, 0.13"
 IterTools = "1"
 OffsetArrays = "1"
 julia = "1.3"

--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -132,7 +132,7 @@ function round_readinds(s,r,an)
 end
 
 function get_readinds(a::InterpolatedDiskArray,r)
-  allnearest = all(i->isa(i,Union{Nothing,BSpline{Constant}}),a.meth)
+  allnearest = all(i->isa(i,Union{Nothing,BSpline{<:Constant}}),a.meth)
   round_readinds.(size(a.a),r,allnearest)
 end
 


### PR DESCRIPTION
In Interpolations 0.13 Constant is becoming a parametric type.
Therefore we need to dispatch on being a subtype.

There are now some failures of the concatdiskarray tests, that seem unrelated.
It looks for me, as if the broadcast test works now and therefore the getindex_list is higher. Is this expected? Should I just change the `@test_broken` to an `@test`and change the numbers accordingly?

Closes #4, closes #1