### PR TITLE
Handle Unions of Missing in CFDiskArray constructor

### DIFF
--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -161,7 +161,8 @@ struct CFDiskArray{T,N,ST,P<:AbstractArray{ST,N}} <: AbstractDiskArray{Union{T,M
     scale_factor::T
 end
 function CFDiskArray(a::AbstractArray{T}, attr::Dict) where T
-  mv = get(attr,"missing_value",get(attr,"_FillValue",typemax(T)))
+  Tnm = nonmissingtype(T)
+  mv = get(attr,"missing_value",get(attr,"_FillValue",typemax(Tnm)))
   offs,sc = if haskey(attr,"add_offset") || haskey(attr,"scale_factor")
     offs = get(attr,"add_offset",zero(Float16))
     sc = get(attr,"scale_factor",one(Float16))
@@ -175,7 +176,7 @@ function CFDiskArray(a::AbstractArray{T}, attr::Dict) where T
     @warn "Could not convert missing value $mv to type $T"
     T<:AbstractFloat ? T(NaN) : typemax(T)
   end
-  CFDiskArray(a, T(mv), offs, sc)
+  CFDiskArray(a, Tnm(mv), offs, sc)
 end
 
 Base.size(a::CFDiskArray, args...) = size(a.a, args...)

--- a/test/cfdiskarray.jl
+++ b/test/cfdiskarray.jl
@@ -1,5 +1,6 @@
 @testset "CF DiskArray" begin
-a = _DiskArray(zeros(Int8,10,10), chunksize = (2,5))
+for T in [Int8, Union{Int8, Missing}]
+a = _DiskArray(zeros(T,10,10), chunksize = (2,5))
 a2 = CFDiskArray(a,Dict("missing_value"=>-128, "add_offset"=>10, "scale_factor"=>1/128))
 
 @test eltype(a2) == Union{Float64,Missing}
@@ -14,4 +15,5 @@ a2[3,:] .= missing
 @test a2[1,:] == fill(9.5,10)
 @test a2[2,:] == fill(10.5,10)
 @test all(ismissing,a2[3,:])
+end
 end


### PR DESCRIPTION
Use the nonmissingtype to allow for types of Union{T, Missing} in the CFDiskArray constructor.

I am not sure, where the Union{Missing, T} is coming from and whether this is the best position to catch these missing types. 
This would fix https://github.com/JuliaDataCubes/EarthDataLab.jl/issues/284.