### PR TITLE
fix promoting of CFArray with offset/scale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /deps/deps.jl
 /docs/build
+/Manifest.toml

--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -224,9 +224,13 @@ end
 function CFDiskArray(a::AbstractArray{T}, attr::Dict) where T
   mv = get(attr,"missing_value",get(attr,"_FillValue",nothing))
   offs,sc = if haskey(attr,"add_offset") || haskey(attr,"scale_factor")
-    offs = get(attr,"add_offset",false)
-    sc = get(attr,"scale_factor",true)
-    promote(offs,sc)
+    _offs = get(attr,"add_offset",false)
+    _sc = get(attr,"scale_factor",true)
+    if _offs isa AbstractFloat && _sc isa AbstractFloat && T <: AbstractFloat
+      T(_offs), T(_sc)
+    else
+      promote(_offs,_sc)
+    end
   else
     zero(T), one(T)
   end

--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -213,6 +213,7 @@ function resample_disk_dimkw(a::AggregatedDiskArray,aout,atemp2,parentranges)
 end
 
 
+remove_missing(::Type{T}) where T <: Union{Missing, T2} where T2 = T2
 
 #Use of Sentinel missing value
 struct CFDiskArray{T,N,MT,P,OT} <: AbstractDiskArray{T,N}
@@ -223,13 +224,14 @@ struct CFDiskArray{T,N,MT,P,OT} <: AbstractDiskArray{T,N}
 end
 function CFDiskArray(a::AbstractArray{T}, attr::Dict) where T
   mv = get(attr,"missing_value",get(attr,"_FillValue",nothing))
-  offs,sc = if haskey(attr,"add_offset") || haskey(attr,"scale_factor")
-    _offs = get(attr,"add_offset",false)
-    _sc = get(attr,"scale_factor",true)
-    if _offs isa AbstractFloat && _sc isa AbstractFloat && T <: AbstractFloat
-      T(_offs), T(_sc)
+  offs, sc = if haskey(attr, "add_offset") || haskey(attr, "scale_factor")
+    _offs = get(attr, "add_offset", false)
+    _sc = get(attr, "scale_factor", true)
+    T2 = remove_missing(T)
+    if _offs isa AbstractFloat && _sc isa AbstractFloat && T2 <: AbstractFloat
+      T2(_offs), T2(_sc)
     else
-      promote(_offs,_sc)
+      promote(_offs, _sc)
     end
   else
     zero(T), one(T)

--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -223,7 +223,7 @@ struct CFDiskArray{T,N,MT,P,OT} <: AbstractDiskArray{T,N}
     scale_factor::OT
 end
 function CFDiskArray(a::AbstractArray{T}, attr::Dict) where T
-  mv = get(attr,"missing_value",get(attr,"_FillValue",nothing))
+  mv = get(attr,"missing_value", nothing)
   offs, sc = if haskey(attr, "add_offset") || haskey(attr, "scale_factor")
     _offs = get(attr, "add_offset", false)
     _sc = get(attr, "scale_factor", true)

--- a/test/cfdiskarray.jl
+++ b/test/cfdiskarray.jl
@@ -36,4 +36,15 @@ b3 = CFDiskArray(b,Dict("add_offset"=>0, "scale_factor"=>1.0))
 b3[3:4] = [12.0, 14.0]
 b3[1:2] = [missing,missing]
 @test all(isequal.(b1[:],[missing,missing,12.0,14.0]))
+
+
+b = CFDiskArray(fill(1f0, 3, 3, 3), Dict("add_offset" => 0.0, "scale_factor" => 1.0))
+@test eltype(b) == Float32
+
+b = CFDiskArray(fill(1f0, 3, 3, 3),
+                Dict("add_offset" => 0.0,
+                     "scale_factor" => 1.0,
+                     "missing_value" => NaN))
+@test eltype(b) == Union{Float32, Missing}
+
 end

--- a/test/cfdiskarray.jl
+++ b/test/cfdiskarray.jl
@@ -47,4 +47,11 @@ b = CFDiskArray(fill(1f0, 3, 3, 3),
                      "missing_value" => NaN))
 @test eltype(b) == Union{Float32, Missing}
 
+b = CFDiskArray([1f0 ,missing],
+                Dict("add_offset" => 0.0,
+                     "scale_factor" => 1.0,
+                     "missing_value" => NaN))
+@test eltype(b) == Union{Float32, Missing}
+
+
 end

--- a/test/cfdiskarray.jl
+++ b/test/cfdiskarray.jl
@@ -53,5 +53,25 @@ b = CFDiskArray([1f0 ,missing],
                      "missing_value" => NaN))
 @test eltype(b) == Union{Float32, Missing}
 
+b = CFDiskArray([1.0f0, missing],
+    Dict("add_offset" => 0.0,
+        "scale_factor" => 1.0))
+@test eltype(b) == Union{Float32,Missing}
 
+
+b = CFDiskArray([1.0f0, missing], Dict())
+@test eltype(b) == Union{Float32,Missing}
+
+b = CFDiskArray([1.0f0, 1.0f0], Dict("missing_value" => NaN))
+@test eltype(b) == Union{Float32,Missing}
+
+b = CFDiskArray([1.0f0, 2.0f0],
+    Dict("add_offset" => 0.0,
+        "scale_factor" => 1.0))
+@test eltype(b) == Float32
+
+# CF conventions prescribe a "_FillValue field"
+b = CFDiskArray([1.0f0, 2.0f0],
+                Dict("_FillValue" => NaN32))
+@test eltype(b) == Float32
 end


### PR DESCRIPTION
[fixes](https://github.com/meggart/DiskArrayTools.jl/issues/15).

I don't quite understand if this is the "correct" way to do it. I guess offset and scaling can be floats while the array is an int type, in this case the promotion makes sense. If the array is a `Float32` and the offset a `Float64`, I don't think the type promotion makes sense, especially because `.zattr` json does not support Float32.