### PR TITLE
Do not convert missing value to eltype of CFDiskArray

### DIFF
--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -252,7 +252,7 @@ function CFDiskArray(a::AbstractArray{T}, attr::Dict) where T
   S,mv = if mv === nothing
     T_pure,mv
   else
-    Union{T_pure,Missing},convert(T_pure,mv)
+    Union{T_pure,Missing},mv
   end
   CFDiskArray{S,ndims(a),typeof(mv),typeof(a),typeof(offs)}(a, mv, offs, sc)
 end

--- a/test/cfdiskarray.jl
+++ b/test/cfdiskarray.jl
@@ -70,6 +70,12 @@ b = CFDiskArray([1.0f0, 2.0f0],
         "scale_factor" => 1.0))
 @test eltype(b) == Float32
 
+b = CFDiskArray([10, -9999],
+    Dict("scale_factor" => Float16(0.1),
+        "missing_value" => -9999))
+@test eltype(b) == Union{Missing, Float16}
+@test ismissing(b[2])
+
 # CF conventions prescribe a "_FillValue field"
 b = CFDiskArray([1.0f0, 2.0f0],
                 Dict("_FillValue" => NaN32))


### PR DESCRIPTION
According to the CF Conventions https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#missing-data the missing data check should be done on the raw data before applying offset and scale_factor. Therefore it should also be in the element type of the raw data.

This would fix the missing value problems I have at RQADeforestation.jl

Tests are added and this is good to go.
