### PR TITLE
Reflect DiskArrays internals renaming

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrayTools"
 uuid = "fcd2136c-9f69-4db6-97e5-f31981721d63"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
@@ -10,7 +10,7 @@ IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
-DiskArrays = "0.3.7, 0.4"
+DiskArrays = "0.3.7, 0.4.10"
 Interpolations = "0.12, 0.13, 0.14, 0.15"
 IterTools = "1"
 OffsetArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
-DiskArrays = "0.3.7, 0.4.10"
+DiskArrays = "0.4.10"
 Interpolations = "0.12, 0.13, 0.14, 0.15"
 IterTools = "1"
 OffsetArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ DiskArrays = "0.4.10"
 Interpolations = "0.12, 0.13, 0.14, 0.15"
 IterTools = "1"
 OffsetArrays = "1"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -1,7 +1,7 @@
 module DiskArrayTools
 import DiskArrays: AbstractDiskArray, eachchunk, haschunks, Chunked,Unchunked,
-estimate_chunksize, GridChunks, findints, readblock!, writeblock!, 
-RegularChunks, IrregularChunks, ChunkType, approx_chunksize, chunktype_from_chunksizes
+estimate_chunksize, GridChunks, readblock!, writeblock!, 
+RegularChunks, IrregularChunks, ChunkVector, approx_chunksize, chunktype_from_chunksizes
 using Interpolations
 using IterTools: imap
 using Base.Iterators: product
@@ -157,7 +157,7 @@ function aggregate_chunks(cs,agg)
   inds = [searchsortedfirst(lagg,lc) for lc in lcs]
   chunktype_from_chunksizes(diff([0;inds]))
 end
-interpret_aggsize(_, x::ChunkType) = x
+interpret_aggsize(_, x::ChunkVector) = x
 interpret_aggsize(sparent,x) = RegularChunks(x,0,sparent)
 
 
@@ -351,14 +351,14 @@ function writeblock!(a::ConcatDiskArray, aout, inds::AbstractUnitRange...)
 end
 
 function mergechunks(a::RegularChunks, b::RegularChunks)
-  if a.s==0 || (a.cs == b.cs && length(last(a))==a.cs)
-    RegularChunks(a.cs, a.offset,a.s+b.s)
+  if a.arraysize==0 || (a.chunksize == b.chunksize && length(last(a))==a.chunksize)
+    RegularChunks(a.chunksize, a.offset,a.arraysize+b.arraysize)
   else
     mergechunks_irregular(a,b)
   end
 end
 
-mergechunks(a::ChunkType, b::ChunkType) = mergechunks_irregular(a,b)
+mergechunks(a::ChunkVector, b::ChunkVector) = mergechunks_irregular(a,b)
 function mergechunks_irregular(a, b)
   IrregularChunks(chunksizes = filter(!iszero,[length.(a); length.(b)]))
 end


### PR DESCRIPTION
Fixes #33 by reflecting the renaming in the DiskArrays internals. 
Tests run successfully locally. 