### PR TITLE
Make Chunked Fill Array hold chunks

### DIFF
--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -378,16 +378,25 @@ function eachchunk(aconc::ConcatDiskArray)
 end
 
 """
-  ChunkedFillArray(v::T, size, chunksize)
-Construct a lazy fill array with a value `v` with the n-dimensional `size` which behaves as a chunked DiskArray with chunks of the size `chunksize`.
+  ChunkedFillArray(value::T, size, chunks)
+Construct a lazy fill array with a value `value` with the n-dimensional `size` which behaves as a chunked DiskArray with a chunking structure of `chunks`.
 """
 struct ChunkedFillArray{T,N} <: AbstractDiskArray{T,N}
-  v::T
-  s::NTuple{N,Int}
-  chunksize::NTuple{N,Int}
+  value::T
+  arrsize::NTuple{N,Int}
+  chunks::GridChunks{N}
+  ChunkedFillArray{T,N}(value, arrsize, chunksize::NTuple{N, Int}) where {T,N} = new{T,N}(value, arrsize, GridChunks(arrsize, chunksize))
+  ChunkedFillArray{T,N}(value, arrsize, chunks::GridChunks{N}) where {T,N} = new{T,N}(value, arrsize, chunks)
 end
-Base.size(x::ChunkedFillArray) = x.s
-readblock!(x::ChunkedFillArray,aout,r::AbstractVector...) = aout .= x.v
-eachchunk(x::ChunkedFillArray) = GridChunks(x.s,x.chunksize)
+
+ChunkedFillArray(value::T, arrsize::NTuple{N, Int}, chunksize::NTuple{N,Int}) where {T,N} = ChunkedFillArray{T,N}(value, arrsize, GridChunks(arrsize, chunksize))
+ChunkedFillArray(value::T, arrsize::NTuple{N, Int}, chunks::GridChunks{N}) where {T,N} = ChunkedFillArray{T,N}(value, arrsize, chunks)
+ChunkedFillArray{T}(value, arrsize::NTuple{N, Int}, chunksize::NTuple{N,Int}) where {T,N} = ChunkedFillArray{T,N}(value, arrsize, GridChunks(arrsize, chunksize))
+ChunkedFillArray{T}(value, arrsize::NTuple{N, Int}, chunks::GridChunks{N}) where {T,N} = ChunkedFillArray{T,N}(value, arrsize, chunks)
+
+
+Base.size(x::ChunkedFillArray) = x.arrsize
+readblock!(x::ChunkedFillArray,aout,r::AbstractVector...) = aout .= x.value
+eachchunk(x::ChunkedFillArray) = x.chunks
 
 end # module

--- a/src/DiskArrayTools.jl
+++ b/src/DiskArrayTools.jl
@@ -381,12 +381,15 @@ end
   ChunkedFillArray(value::T, size, chunks)
 Construct a lazy fill array with a value `value` with the n-dimensional `size` which behaves as a chunked DiskArray with a chunking structure of `chunks`.
 """
-struct ChunkedFillArray{T,N} <: AbstractDiskArray{T,N}
+struct ChunkedFillArray{T,N,C} <: AbstractDiskArray{T,N}
   value::T
   arrsize::NTuple{N,Int}
-  chunks::GridChunks{N}
-  ChunkedFillArray{T,N}(value, arrsize, chunksize::NTuple{N, Int}) where {T,N} = new{T,N}(value, arrsize, GridChunks(arrsize, chunksize))
-  ChunkedFillArray{T,N}(value, arrsize, chunks::GridChunks{N}) where {T,N} = new{T,N}(value, arrsize, chunks)
+  chunks::C
+  function ChunkedFillArray{T,N}(value, arrsize, chunksize::NTuple{N, Int}) where {T,N}
+    chunks = GridChunks(arrsize, chunksize)  
+    new{T,N, typeof(chunks)}(value, arrsize, chunks)
+  end
+  ChunkedFillArray{T,N}(value, arrsize, chunks::GridChunks{N}) where {T,N} = new{T,N, typeof(chunks)}(value, arrsize, chunks)
 end
 
 ChunkedFillArray(value::T, arrsize::NTuple{N, Int}, chunksize::NTuple{N,Int}) where {T,N} = ChunkedFillArray{T,N}(value, arrsize, GridChunks(arrsize, chunksize))

--- a/test/chunkedfillarray.jl
+++ b/test/chunkedfillarray.jl
@@ -5,4 +5,28 @@ using DiskArrays, DiskArrayTools
     @test eltype(a) == Int
     @test all(==(1), a)
     @test eachchunk(a) isa  DiskArrays.GridChunks
+    afloat = ChunkedFillArray{Float64,2}(1,(100,100), (10,10))
+    @test eltype(afloat) == Float64
+    @test all(==(1.), a)
+    @test eachchunk(a) isa DiskArrays.GridChunks
+    afloat = ChunkedFillArray{Float64}(1,(100,100), (10,10))
+    @test eltype(afloat) == Float64
+    @test all(==(1.), a)
+    @test eachchunk(a) isa DiskArrays.GridChunks
+end
+
+@testset "Chunked Fill Array Chunks provided" begin
+    chunks = DiskArrays.GridChunks(DiskArrays.IrregularChunks([0,20,50,100]), DiskArrays.RegularChunks(10,0,100))
+    a = ChunkedFillArray(1, (100,100),chunks)
+    @test eltype(a) == Int
+    @test all(==(1), a)
+    @test eachchunk(a) isa  DiskArrays.GridChunks
+    afloat = ChunkedFillArray{Float64,2}(1,(100,100), chunks)
+    @test eltype(afloat) == Float64
+    @test all(==(1.), a)
+    @test eachchunk(a) isa DiskArrays.GridChunks
+    afloat = ChunkedFillArray{Float64}(1,(100,100), chunks)
+    @test eltype(afloat) == Float64
+    @test all(==(1.), a)
+    @test eachchunk(a) isa DiskArrays.GridChunks
 end


### PR DESCRIPTION
This moves the construction of regular chunks from the eachchunk call to the constructor of the Chunked FillArray. This enables to reuse the existing chunking pattern of actual data when constructing a ChunkedFillArray.

Currently `haschunks(::ChunkedFillArray)` is false and I am wondering whether we should hard code this to true but I can't overview what this would entail. 
